### PR TITLE
docs: add mix deps.get to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You need only to get the code, from source code you can:
 ```
 git clone https://github.com/altenwald/lambdapad
 cd lambdapad
+mix deps.get
 mix escript.build
 ```
 


### PR DESCRIPTION
I think it is necessary to specify that it is necessary to run mix deps.get before to build the script.

Maybe it is easy to guess the need for this command, but it can save a few seconds and avoid the error message:

```
Unchecked dependencies for environment dev:
* pockets (Hex package)
  the dependency is not available, run "mix deps.get"
* erlydtl (https://github.com/manuel-rubio/erlydtl.git)
  the dependency is not available, run "mix deps.get"
* cowboy (Hex package)
  the dependency is not available, run "mix deps.get"
* earmark (https://github.com/manuel-rubio/earmark.git)
  the dependency is not available, run "mix deps.get"
* optimus (Hex package)
  the dependency is not available, run "mix deps.get"
* toml (Hex package)
  the dependency is not available, run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
```